### PR TITLE
changed spacing in tranposed p1000 tip rack

### DIFF
--- a/equipment.py
+++ b/equipment.py
@@ -14,7 +14,7 @@ def getEquipment():
         equipment['trash']=containers.load('point', "C1","trash")
         equipment['p200rack'] = containers.load('tiprack-200ul', 'E2', 'tiprack200')
         if TransposeTipBox:
-             equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.02,9.02),diameter=5,depth=85,Transposed=True)
+             equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.02,-9.02),diameter=5,depth=85,Transposed=True)
         else:
              equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.02,9.02),diameter=5,depth=85)
         equipment['CulturePlate']  = containers.load('24corning', 'B2', 'CulturePlate24')


### PR DESCRIPTION
The spacing has been changed so that the first tip to be picked up can now be in the A1 position of the tip rack and the next one will be in A2 position, i.e. one step closer to the front edge of the deck. Although the previous spacing is consistent with the general layout of the deck with row A closest to the front edge, it seems more intuitive to have the first tip picked up from the top left (A1) position of a tip rack.