### PR TITLE
Adding a page to allow running arbitrary robot commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs
 calibrations
 plasmotron.db
 _*_
+containers

--- a/app.py
+++ b/app.py
@@ -341,6 +341,25 @@ def add_manual_action():
   flash('The action was successfully added')
   return redirect(url_for('show_culture', cultureID=request.form['cultureid']))
 
+@app.route('/addmanualactionforchechcalib', methods=['POST'])
+def add_manual_action_for_check_calib():
+
+  doAction = request.form['doAction']
+  usePipette = request.form['usePipette']
+  useContainer = request.form['useContainer'] or None
+  useRow = request.form['useRow'] or None
+  useCol = request.form['useCol'] or None
+  useVolume = request.form['useVolume'] or None
+
+  db = get_db()
+  db.execute(
+      'insert into CommandQueue (Command,Pipette,Labware,Row,Column,Volume,queued) values (?,?,?,?,?,?,?)',
+      [
+          doAction, usePipette, useContainer, useRow,useCol,useVolume,1
+      ])
+  db.commit()
+  return redirect(url_for('checkCalibration'))
+
 
 @app.route('/processplate', methods=['POST'])
 def process_plate():
@@ -1330,6 +1349,11 @@ FROM
 def addPlateForm():
   return render_template('newPlateForm.html')
 
+
+@app.route('/checkCalibration')
+def checkCalibration():
+  db = get_db()
+  return render_template('checkCalibration.html')
 
 atexit.register(cleanup)
 

--- a/equipment.py
+++ b/equipment.py
@@ -14,9 +14,9 @@ def getEquipment():
         equipment['trash']=containers.load('point', "C1","trash")
         equipment['p200rack'] = containers.load('tiprack-200ul', 'E2', 'tiprack200')
         if TransposeTipBox:
-             equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.02,-9.02),diameter=5,depth=85,Transposed=True)
+             equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.1,-9.1),diameter=5,depth=85,Transposed=True)
         else:
-             equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.02,9.02),diameter=5,depth=85)
+             equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.00,9.00),diameter=5,depth=85)
         equipment['CulturePlate']  = containers.load('24corning', 'B2', 'CulturePlate24')
         equipment['CulturePlate96']  = containers.load('96-flat', 'B2')
         equipment['CulturePlate2']  = containers.load('24corning', 'C2', 'CulturePlate242')

--- a/equipment.py
+++ b/equipment.py
@@ -16,7 +16,7 @@ def getEquipment():
         if TransposeTipBox:
              equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.1,-9.1),diameter=5,depth=85,Transposed=True)
         else:
-             equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.00,9.00),diameter=5,depth=85)
+             equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.1,9.1),diameter=5,depth=85)
         equipment['CulturePlate']  = containers.load('24corning', 'B2', 'CulturePlate24')
         equipment['CulturePlate96']  = containers.load('96-flat', 'B2')
         equipment['CulturePlate2']  = containers.load('24corning', 'C2', 'CulturePlate242')

--- a/equipment.py
+++ b/equipment.py
@@ -14,9 +14,9 @@ def getEquipment():
         equipment['trash']=containers.load('point', "C1","trash")
         equipment['p200rack'] = containers.load('tiprack-200ul', 'E2', 'tiprack200')
         if TransposeTipBox:
-             equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.1,-9.1),diameter=5,depth=85,Transposed=True)
+             equipment['p1000rack']  = create_container_instance("TR1000-Transposed",slot="A1",grid=(8,12),spacing=(9.02,-9.02),diameter=5,depth=85,Transposed=True)
         else:
-             equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.1,9.1),diameter=5,depth=85)
+             equipment['p1000rack']  = create_container_instance("TR1000-Normal",slot="A1",grid=(8,12),spacing=(9.02,9.02),diameter=5,depth=85)
         equipment['CulturePlate']  = containers.load('24corning', 'B2', 'CulturePlate24')
         equipment['CulturePlate96']  = containers.load('96-flat', 'B2')
         equipment['CulturePlate2']  = containers.load('24corning', 'C2', 'CulturePlate242')

--- a/templates/checkCalibration.html
+++ b/templates/checkCalibration.html
@@ -1,0 +1,105 @@
+{% extends "layout.html" %}
+{% block body %}
+ 
+<script>
+$(document).ready(function(){
+  $('#runCmdButton').click(function() { 
+        $.ajax({
+            url: 'addmanualactionforchechcalib',
+            type: 'POST',
+            data: form.serialize()
+        });  
+  });
+});
+</script>
+
+<h2>check and adjust calibrations</h2>
+
+<p>Run a command and add to the queue</p>
+<form action='/addmanualactionforchechcalib' method="post" name="robotActionsForm">
+  <p>
+  pipette 
+  <select name="usePipette">
+    <option value="p1000">p1000</option>
+    <option value="p200">p200</option>
+  </select>
+  </p>
+
+  <p>
+    container
+    <select name="useContainer">
+      <option value="">none</option>
+      <option value="CulturePlate">CulturePlate</option>
+      <option value="CulturePlate2">CulturePlate2</option>
+      <option value="AliquotPlate">AliquotPlate</option>
+      <option value="p1000rack">p1000rack</option>
+      <option value="trash">trash</option>
+      <option value="TubBlood">TubBlood</option>
+      <option value="TubMedia">TubMedia</option>
+      <option value="TubSybr">TubSybr</option>
+    </select>
+  </p>
+  <p>
+    row
+    <select name="useRow">
+      <option value="">none</option>
+      <option value="0">A</option>
+      <option value="1">B</option>
+      <option value="2">C</option>
+      <option value="3">D</option>
+      <option value="4">E</option>
+      <option value="5">F</option>
+      <option value="6">G</option>
+      <option value="7">H</option>
+    </select>
+  </p>
+
+  <p>
+    column
+    <select name="useCol">
+      <option value="">none</option>
+      <option value="0">1</option>
+      <option value="1">2</option>
+      <option value="2">3</option>
+      <option value="3">4</option>
+      <option value="4">5</option>
+      <option value="5">6</option>
+      <option value="6">7</option>
+      <option value="7">8</option>
+      <option value="8">9</option>
+      <option value="9">10</option>
+      <option value="10">11</option>
+      <option value="11">12</option>
+    </select>
+  </p>
+
+
+  <p>
+    action
+    <select name="doAction">
+      <option value="GetTips">GetTips</option>
+      <option value="Aspirate">Aspirate</option>
+      <option value="Dispense">Dispense</option>
+      <option value="DropTip">DropTip</option>
+      <option value="AirGap">AirGap</option>
+      <option value="DispenseBottom">DispenseBottom</option>
+      <option value="Resuspend">Resuspend</option>
+      <option value="Home">Home</option>
+      <option value="resuspendReservoir">resuspendReservoir</option>
+      <option value="ResuspendDouble">ResuspendDouble</option>
+      <option value="ResuspendReservoir">ResuspendReservoir</option>
+      <option value="InitaliseLabware">InitaliseLabware</option>
+    </select>
+  </p>
+
+  <p>
+  volume
+  <input type="text" name="useVolume">
+  </p>
+  <p>
+  <button id="runCmdButton">run command</button>
+  </p>
+</form> 
+
+
+{% endblock %}


### PR DESCRIPTION
I have added a page "/checkCalibration" that I find useful in the calibration process. It allows building commands for the command queue, e.g. to check that tips are correctly picked up across the tip rack after calibration to the A1 tip. It is also useful for trying/developing new protocols. Commands are run immediately.
This is functional but not fully finished yet. It still needs some javascript to adjust the selectable parameters according to the labware. For that reason, I haven't yet added links to this page on any other page, so it is there for those who know about it but not so visible to the normal end user. We might need to go a step further and protect this page with a simple admin login (harcoded password should be enough) because it would be possible to use this feature to interfere with a running protocol and dispense liquids in arbitrary places, which could be a hazard.