### PR TITLE
making the checkCalibration page a bit more intelligent

### DIFF
--- a/templates/checkCalibration.html
+++ b/templates/checkCalibration.html
@@ -10,16 +10,131 @@ $(document).ready(function(){
             data: form.serialize()
         });  
   });
+
+  var optionsForContainer = {
+    "CulturePlate" : {
+      allowedActions : [ "Aspirate", "Dispense", "AirGap", 
+        "DispenseBottom","Resuspend","ResuspendDouble","Home" ],
+      maxRow : 4,
+      maxCol : 6,
+      selectedAction : 'Aspirate',
+      disabledInputs : [],
+    },
+    "CulturePlate2" : {
+      allowedActions : [ "Aspirate", "Dispense", "AirGap", 
+        "DispenseBottom","Resuspend","ResuspendDouble","Home" ],
+      maxRow : 4,
+      maxCol : 6,
+      selectedAction : 'Aspirate',
+      disabledInputs : [],
+    },
+    "AliquotPlate" : {
+      allowedActions : [ "Aspirate", "Dispense", "AirGap", 
+        "DispenseBottom","Resuspend","ResuspendDouble","Home" ],
+      maxRow : 8,
+      maxCol : 12,
+      selectedAction : 'Dispense',
+      disabledInputs : [],
+    },
+    "p1000rack" : {
+      allowedActions : [ "GetTips", "Home" ], 
+      maxRow : 8,
+      maxCol : 12,
+      selectedAction : 'GetTips',
+      disabledInputs : [ "useVolume" ],
+    },
+    "trash" : {
+      allowedActions : [ "DropTip", "Home" ], 
+      selectedAction : 'DropTip',
+      disabledInputs : [ "useVolume","useRow", "useCol" ],
+    },
+    "TubBlood" : {
+      allowedActions : [ "Aspirate", "Dispense", "AirGap", 
+        "ResuspendReservoir","Home" ],
+      selectedAction : 'Aspirate',
+      disabledInputs : [ "useRow", "useCol" ],
+    },
+    "TubSybr" : {
+      allowedActions : [ "Aspirate", "Dispense", "AirGap", 
+        "ResuspendReservoir","Home" ],
+      selectedAction : 'Aspirate',
+      disabledInputs : [ "useRow", "useCol" ],
+    },
+    "TubMedia" : {
+      allowedActions : [ "Aspirate", "Dispense", "AirGap", 
+        "ResuspendReservoir","Home" ],
+      selectedAction : 'Aspirate',
+      disabledInputs : [ "useRow", "useCol" ],
+    }
+  };
+
+  // reset the available field options depending on container
+  $('#useContainer').change(function(){
+    var selectedContainer = $("#useContainer option:selected").val();
+    if( selectedContainer in optionsForContainer ){
+      resetOptions( "robotActionsForm", optionsForContainer[ selectedContainer ] );
+    }
+  });
 });
+
+// takes dictionary of options to reset in the form
+function resetOptions( formId, optionsDict ){
+  // bring all form decendant fields to active state
+  // then disable according to list if there is one
+  $("#" + formId + " *").prop("disabled", false)
+  
+    if ( "disabledInputs" in optionsDict ){
+    $( optionsDict["disabledInputs"].map( x => "#"+x ).join(", ") ).prop("disabled","disabled");
+  }
+  
+  if ( "allowedActions" in optionsDict ){
+    selectAllow( "doAction", optionsDict["allowedActions"] );
+  }
+  
+  if ( "selectedAction" in optionsDict ){
+    $("#doAction").val( optionsDict["selectedAction"] );
+  }
+
+  // bring rows/cols to known state by repopulating, either
+  // with all or with rows/cols up to a maximum (index)
+  var rows = [ "A", "B", "C", "D", "E", "F", "G", "H" ];
+  var cols = [ 1,2,3,4,5,6,7,8,9,10,11,12 ];
+  var rowField = $("#useRow");
+  rowField.empty();
+  $.each( rows, function( i, val ) {
+    rowField.append(  $("<option></option>")
+      .attr("value", i).text(val) );
+    if ( "maxRow" in optionsDict && optionsDict["maxRow"] == i + 1){ return(false); };
+  });
+  var colField = $("#useCol");
+  colField.empty();
+  $.each( cols, function( i, val ) {
+    colField.append(  $("<option></option>")
+      .attr("value", i).text(val) );
+   if ( "maxCol" in optionsDict && optionsDict["maxCol"] == i + 1){ return(false); };
+  });
+}
+
+// sets options for a select field
+function selectAllow( selectFieldId, allowOptions ){
+  var selectField = $("#" + selectFieldId);
+  // repopulate the options
+  selectField.empty();
+  $.each( allowOptions, function(i,val){
+    selectField.append( $("<option></option>")
+      .attr("value", val).text(val));
+  });
+}
 </script>
+
 
 <h2>check and adjust calibrations</h2>
 
 <p>Run a command and add to the queue</p>
-<form action='/addmanualactionforchechcalib' method="post" name="robotActionsForm">
+<form action='/addmanualactionforchechcalib' method="post" name="robotActionsForm" id="robotActionsForm">
   <p>
   pipette 
-  <select name="usePipette">
+  <select name="usePipette" id="usePipette">
     <option value="p1000">p1000</option>
     <option value="p200">p200</option>
   </select>
@@ -27,7 +142,7 @@ $(document).ready(function(){
 
   <p>
     container
-    <select name="useContainer">
+    <select name="useContainer" id="useContainer">
       <option value="">none</option>
       <option value="CulturePlate">CulturePlate</option>
       <option value="CulturePlate2">CulturePlate2</option>
@@ -41,8 +156,7 @@ $(document).ready(function(){
   </p>
   <p>
     row
-    <select name="useRow">
-      <option value="">none</option>
+    <select name="useRow" id="useRow">
       <option value="0">A</option>
       <option value="1">B</option>
       <option value="2">C</option>
@@ -56,8 +170,7 @@ $(document).ready(function(){
 
   <p>
     column
-    <select name="useCol">
-      <option value="">none</option>
+    <select name="useCol" id="useCol">
       <option value="0">1</option>
       <option value="1">2</option>
       <option value="2">3</option>
@@ -76,7 +189,7 @@ $(document).ready(function(){
 
   <p>
     action
-    <select name="doAction">
+    <select name="doAction" id="doAction">
       <option value="GetTips">GetTips</option>
       <option value="Aspirate">Aspirate</option>
       <option value="Dispense">Dispense</option>
@@ -85,7 +198,6 @@ $(document).ready(function(){
       <option value="DispenseBottom">DispenseBottom</option>
       <option value="Resuspend">Resuspend</option>
       <option value="Home">Home</option>
-      <option value="resuspendReservoir">resuspendReservoir</option>
       <option value="ResuspendDouble">ResuspendDouble</option>
       <option value="ResuspendReservoir">ResuspendReservoir</option>
       <option value="InitaliseLabware">InitaliseLabware</option>
@@ -94,7 +206,7 @@ $(document).ready(function(){
 
   <p>
   volume
-  <input type="text" name="useVolume">
+  <input type="text" name="useVolume" id="useVolume">
   </p>
   <p>
   <button id="runCmdButton">run command</button>


### PR DESCRIPTION
I have added some more javascript on the chckCalibration page to update the available fields depending on the chosen container. This makes it easier to create the commands the suer will want to create and makes it harder to issue nonsensical commands. I have yet to add another level of dynamic updates depending on the selected action, such as disabling volume where it is not needed. Will come soon.