### PR TITLE
change to plate measurement file handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1189,19 +1189,19 @@ def uploadReadings():
       measurements = 0
       text = file.read()
       for l in text.splitlines():
-        mylist = str(l).split(',')
-        name = mylist[0]
-        mylist2 = name.split('-')
+        column_values = str(l).split(',')
+        well_name = column_values[0]
+        well_name_split = well_name.split('-')
         # get the last element of the first column: this will be the well reference on the measurement plate: A1, C3, etc.
-        location = mylist2[len(mylist2) - 1] 
+        location = well_name_split[len(well_name_split) - 1] 
         # if there are only two columns, then column 2 will have the parasitaemia
         # measurements. If there are more than 5 then this is the old
         # format and measurements should be in column 8
-        if len(mylist2) > 2:
-          if len(mylist) == 2 :
-            percent = mylist[1]
-          elif len(mylist) > 7 :
-            percent = mylist[7]
+        if len(well_name_split) > 2:
+          if len(column_values) == 2 :
+            percent = column_values[1]
+          elif len(column_values) > 7 :
+            percent = column_values[7]
 
           if percent != '':
             percent = float(re.findall(r'[-+]?\d*\.\d+|\d+', percent)[0])

--- a/app.py
+++ b/app.py
@@ -1194,10 +1194,12 @@ def uploadReadings():
         well_name_split = well_name.split('-')
         # get the last element of the first column: this will be the well reference on the measurement plate: A1, C3, etc.
         location = well_name_split[len(well_name_split) - 1] 
-        # if there are only two columns, then column 2 will have the parasitaemia
-        # measurements. If there are more than 5 then this is the old
-        # format and measurements should be in column 8
+     
         if len(well_name_split) > 2: #this skips non-data lines at the top of the CSV
+               
+          # if there are only two columns, then column 2 will have the parasitaemia
+          # measurements. If there are more than 5 then this is the old
+          # format and measurements should be in column 8
           if len(column_values) == 2 :
             percent = column_values[1]
           elif len(column_values) > 7 :

--- a/app.py
+++ b/app.py
@@ -1181,10 +1181,9 @@ def uploadReadings():
       flash('No CSV file')
       return redirect(url_for('show_plate', plateID=request.form['plateID']))
     file = request.files['file']
-    # if user does not select file, browser also
-    # submit a empty part without filename
+    # if user does not select file, the browser submits an empty filename:
     if file.filename == '':
-      flash('No selected file')
+      flash('Please select a file to upload')
       return redirect(url_for('show_plate', plateID=request.form['plateID']))
     if file and allowed_file(file.filename):
       measurements = 0
@@ -1193,8 +1192,9 @@ def uploadReadings():
         mylist = str(l).split(',')
         name = mylist[0]
         mylist2 = name.split('-')
-        location = mylist2[len(mylist2) - 1]
-        # if there are only two columns, then column 2 will have the
+        # get the last element of the first column: this will be the well reference on the measurement plate: A1, C3, etc.
+        location = mylist2[len(mylist2) - 1] 
+        # if there are only two columns, then column 2 will have the parasitaemia
         # measurements. If there are more than 5 then this is the old
         # format and measurements should be in column 8
         if len(mylist2) > 2:
@@ -1213,7 +1213,7 @@ def uploadReadings():
                   'INSERT INTO Measurements (PlateID,Row,Column,MeasurementValue) values (?,?,?,?)',
                   [request.form['plateID'], row, col, percent])
             except sqlite3.IntegrityError:
-              flash('ERROR: duplicated entries - these measurements have been uploaded previously')
+              flash('ERROR: Duplicated entries - some of these measurement wells have already had data uploaded to them. Please delete these measurements before uploading replacement data.')
               return redirect(url_for('show_plate', plateID=request.form['plateID']))
             except:
               flash('ERROR: Loading data into database failed. Please contact administrator.')

--- a/app.py
+++ b/app.py
@@ -1197,7 +1197,7 @@ def uploadReadings():
         # if there are only two columns, then column 2 will have the parasitaemia
         # measurements. If there are more than 5 then this is the old
         # format and measurements should be in column 8
-        if len(well_name_split) > 2:
+        if len(well_name_split) > 2: #this skips non-data lines at the top of the CSV
           if len(column_values) == 2 :
             percent = column_values[1]
           elif len(column_values) > 7 :

--- a/app.py
+++ b/app.py
@@ -1215,8 +1215,8 @@ def uploadReadings():
             except sqlite3.IntegrityError:
               flash('ERROR: Duplicated entries - some of these measurement wells have already had data uploaded to them. Please delete these measurements before uploading replacement data.')
               return redirect(url_for('show_plate', plateID=request.form['plateID']))
-            except:
-              flash('ERROR: Loading data into database failed. Please contact administrator.')
+            except Exception as e:
+              flash('ERROR: Loading data into database failed. Please contact administrator. <br><br>Error:'+str(e))
               return redirect(url_for('show_plate', plateID=request.form['plateID']))
             measurements = measurements + 1
       db.execute('UPDATE Plates SET PlateFinished=1 WHERE PlateID=?',

--- a/app.py
+++ b/app.py
@@ -1174,6 +1174,9 @@ def allowed_file(filename):
 
 @app.route('/uploadReadings', methods=['POST'])
 def uploadReadings():
+  # TODO(theosanderson): At present this is all set up just for CytoFlex CSV files. 
+  # We should abstract all this into a cytoflex specific class, provide alternatives,
+  # and a way of configuring which one is to be used.
   db = get_db()
   if request.method == 'POST':
     # check if the post request has the file part


### PR DESCRIPTION
Request from lab users: if a measurements file only has 2 columns (which can be set up in the Cytoflex) then use column 2 for the measurements. If it has at least 8 columns, use column 8 for measurements, as before to keep compatibility with older files.
There is also now a test for duplicated entries to throw a meaningful error if a measurement is attempted to be loaded repeatedly. 